### PR TITLE
fix(test): resolve Firefox dropdown navigation test failures

### DIFF
--- a/e2e/navigation.spec.ts
+++ b/e2e/navigation.spec.ts
@@ -8,21 +8,19 @@ test.describe('Navigation', () => {
     await page.goto('/');
 
     // Test Philippines dropdown menu
-    await navigate(page, 'Philippines');
     if (isMobile) {
+      await navigate(page, 'Philippines');
       await expect(
         page.getByRole('link', { name: 'About the Philippines' })
       ).toBeVisible();
+      // Navigate to About Philippines
+      await navigate(page, null, 'About the Philippines', false);
     } else {
-      await expect(
-        page.getByRole('menuitem', { name: 'About the Philippines' })
-      ).toBeVisible();
+      // For desktop, navigate directly to the submenu item
+      await navigate(page, 'Philippines', 'About the Philippines');
     }
 
-    // Navigate to About Philippines
-    await navigate(page, null, 'About the Philippines', false);
-
-    await expect(page.url()).toContain('/philippines/about');
+    expect(page.url()).toContain('/philippines/about');
     await expect(page.getByRole('heading', { level: 1 })).toContainText(
       'About the Philippines'
     );
@@ -52,7 +50,7 @@ test.describe('Navigation', () => {
       .getByRole('link', { name: /Join Us/i })
       .first()
       .click();
-    await expect(page.url()).toContain('/join-us');
+    expect(page.url()).toContain('/join-us');
     await expect(page.getByRole('heading').first()).toContainText(
       'Join the #CivicTech Revolution'
     );
@@ -63,7 +61,7 @@ test.describe('Navigation', () => {
 
     // Click Project Ideas link
     await page.getByRole('link', { name: 'Project Ideas' }).first().click();
-    await expect(page.url()).toContain('/ideas');
+    expect(page.url()).toContain('/ideas');
   });
 
   test('should have working footer links', async ({ page }) => {
@@ -78,7 +76,7 @@ test.describe('Navigation', () => {
       .getByRole('link', { name: 'About' });
     await expect(aboutLink).toBeVisible();
     await aboutLink.click();
-    await expect(page.url()).toContain('/about');
+    expect(page.url()).toContain('/about');
 
     // Go back to homepage
     await page.goto('/');
@@ -90,7 +88,7 @@ test.describe('Navigation', () => {
       .getByRole('link', { name: 'Sitemap' });
     await expect(sitemapLink).toBeVisible();
     await sitemapLink.click();
-    await expect(page.url()).toContain('/sitemap');
+    expect(page.url()).toContain('/sitemap');
   });
 
   test('branch navigation should work', async ({ page }) => {
@@ -109,6 +107,6 @@ test.describe('Navigation', () => {
 
     branch = page.locator('a.bg-primary-500').first();
     await expect(branch).toContainText('Local Government Units');
-    await expect(page.url()).toContain('/government/local');
+    expect(page.url()).toContain('/government/local');
   });
 });

--- a/e2e/utils/navbar.ts
+++ b/e2e/utils/navbar.ts
@@ -42,13 +42,24 @@ export async function navigate(
 
   // For desktop
   if (option) {
-    await page.getByRole('link', { name: option, exact: true }).first().hover();
-  }
+    const linkElement = page
+      .getByRole('link', { name: option, exact: true })
+      .first();
 
-  if (subOption) {
-    await page
-      .getByRole('menuitem', { name: subOption, exact: true })
-      .first()
-      .click();
+    // If we have a subOption, use a more direct approach
+    if (subOption) {
+      // Hover over the main link
+      await linkElement.hover();
+
+      // Wait for the menu item to be visible
+      const menuItem = page.getByRole('menuitem', { name: subOption }).first();
+      await menuItem.waitFor({ state: 'visible', timeout: 5000 });
+
+      // Click the menu item
+      await menuItem.click({ timeout: 10000 });
+    } else {
+      // Just hover if no subOption
+      await linkElement.hover();
+    }
   }
 }

--- a/src/components/layout/Navbar.tsx
+++ b/src/components/layout/Navbar.tsx
@@ -15,6 +15,7 @@ import { LanguageType } from '../../types';
 const Navbar: React.FC = () => {
   const [isOpen, setIsOpen] = useState(false);
   const [activeMenu, setActiveMenu] = useState<string | null>(null);
+  const [hoveredDropdown, setHoveredDropdown] = useState<string | null>(null);
   const { t, i18n } = useTranslation('common');
 
   const toggleMenu = () => {
@@ -35,6 +36,14 @@ const Navbar: React.FC = () => {
 
   const changeLanguage = (newLanguage: LanguageType) => {
     i18n.changeLanguage(newLanguage);
+  };
+
+  const handleDropdownMouseEnter = (label: string) => {
+    setHoveredDropdown(label);
+  };
+
+  const handleDropdownMouseLeave = () => {
+    setHoveredDropdown(null);
   };
 
   return (
@@ -103,7 +112,12 @@ const Navbar: React.FC = () => {
           {/* Desktop navigation */}
           <div className='hidden lg:flex items-center space-x-8 pr-24'>
             {mainNavigation.map(item => (
-              <div key={item.label} className='relative group'>
+              <div
+                key={item.label}
+                className='relative group'
+                onMouseEnter={() => handleDropdownMouseEnter(item.label)}
+                onMouseLeave={handleDropdownMouseLeave}
+              >
                 <Link
                   to={item.href}
                   className='flex items-center text-gray-700 hover:text-primary-600 font-medium transition-colors'
@@ -114,7 +128,13 @@ const Navbar: React.FC = () => {
                   )}
                 </Link>
                 {item.children && (
-                  <div className='absolute left-0 mt-2 w-56 rounded-md shadow-lg bg-white ring-1 ring-black/5 opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all duration-200 z-50'>
+                  <div
+                    className={`absolute left-0 mt-2 w-56 rounded-md shadow-lg bg-white ring-1 ring-black/5 transition-all duration-200 z-50 ${
+                      hoveredDropdown === item.label
+                        ? 'opacity-100 visible'
+                        : 'opacity-0 invisible'
+                    }`}
+                  >
                     <div
                       className='py-1'
                       role='menu'


### PR DESCRIPTION
- Replace CSS-only hover states with JavaScript-based hover handling
- Add React state management for dropdown visibility control
- Update navbar component to use onMouseEnter/onMouseLeave handlers
- Ensure consistent dropdown behavior across all browsers
- Simplify test utility to use standard hover approach